### PR TITLE
Fix delay 0

### DIFF
--- a/support/Arduino.h
+++ b/support/Arduino.h
@@ -76,8 +76,6 @@ void noTone(int pin);
 /* Time */
 unsigned long millis(void);
 unsigned long micros(void);
-void delay(unsigned long msecs);
-void delayMicroseconds(unsigned int usecs);
 
 /* Serial IO */
 int serialCanGetChar(void);
@@ -107,6 +105,10 @@ long randomSeed(unsigned long seed);
 };
 #endif
 #endif /* !ARDUINO_OS */
+
+/* Time functions that get patched in C code */
+void delay(unsigned long msecs);
+void delayMicroseconds(unsigned int usecs);
 
 /* Undef this, as there's no difference between the types of memory */
 #define PROGMEM

--- a/support/arduino-time.cpp
+++ b/support/arduino-time.cpp
@@ -1,0 +1,14 @@
+#include "Arduino.h"
+
+extern "C" void delay_c(unsigned long msecs);
+extern "C" void delayMicroseconds_c(unsigned int usecs);
+
+void delay(unsigned long msecs) {
+  delay_c(msecs);
+}
+
+void delayMicroseconds(unsigned int usecs) {
+  if (!usecs)
+    return;
+  delayMicroseconds_c(usecs);
+}

--- a/support/syscalls-app.cpp
+++ b/support/syscalls-app.cpp
@@ -987,8 +987,16 @@ extern "C" {
       asm("svc #105");
     }
     __attribute__((naked))
+    void delay_c(unsigned long msecs) {
+      asm("svc #106");
+    }
+    __attribute__((naked))
     void delay(unsigned long msecs) {
       asm("svc #106");
+    }
+    __attribute__((naked))
+    void delayMicroseconds_c(unsigned int usecs) {
+      asm("svc #107");
     }
     __attribute__((naked))
     void delayMicroseconds(unsigned int usecs) {

--- a/support/syscalls-db.txt
+++ b/support/syscalls-db.txt
@@ -192,8 +192,8 @@ r
 # Arduino time management
 P | millis | unsigned long | void
 P | micros | unsigned long | void
-P | delay | void | unsigned long msecs
-P | delayMicroseconds | void | unsigned int usecs
+P | delay | void | unsigned long msecs | delay_c
+P | delayMicroseconds | void | unsigned int usecs | delayMicroseconds_c
 
 
 # Arduino math


### PR DESCRIPTION
Simply "return" when calling delay().

Note that this does increase the size of delay() by quite a bit.  It is now 10 bytes instead of 2.  We may be able to lower this to four bytes, if such optimizations are desired.  But for now, this addresses the problem.