### PR TITLE
Fix internal compiler error for cascade example

### DIFF
--- a/support/crt0.c
+++ b/support/crt0.c
@@ -14,5 +14,6 @@ void raise(void) {
   while(1);
 }
 
-/* handle for C++ destructors, which we don't use. */
-uint32_t __dso_handle = 0;
+// handle for C++ destructors, which we don't use.
+// Taken from https://lists.debian.org/debian-gcc/2003/07/msg00070.html
+void*   __dso_handle = (void*) &__dso_handle;

--- a/support/variant.cpp
+++ b/support/variant.cpp
@@ -36,7 +36,7 @@ extern uint32_t __init_array_end;
 extern uint32_t __heap_base__;
 extern uint32_t __heap_end__;
 
-__attribute__((naked, noreturn))
+__attribute__((noreturn))
 void Esplanade_Main(void) {
 
   setup();


### PR DESCRIPTION
This patch removes the "naked" attribute for Esplanade_Main().

This was causing Internal Compiler Errors with no clear origin.  It is unclear why this is causing a problem only now, but many other projects using the same version of GCC are reporting similar issues.

Additionally, we re-define __dso_handle as something that doesn't generate a warning anymore.